### PR TITLE
Accept Python 3.11.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name="cloudbees-openfeature-provider-python"
 authors=[{name = "CloudBees", email = "support@cloudbees.com"}]
 description="CloudBees.com OpenFeature SDK"
 keywords=["CloudBees", "OpenFeature"]
-requires-python= ">=3.8, <3.12"
+requires-python= ">=3.8"
 readme = "README.md"
 dependencies = [
     'rox >= 5.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name="cloudbees-openfeature-provider-python"
 authors=[{name = "CloudBees", email = "support@cloudbees.com"}]
 description="CloudBees.com OpenFeature SDK"
 keywords=["CloudBees", "OpenFeature"]
-requires-python= ">=3.8, <=3.11"
+requires-python= ">=3.8, <3.12"
 readme = "README.md"
 dependencies = [
     'rox >= 5.0',


### PR DESCRIPTION
Current `requires-python` definition does not accept Python 3.11 version above 3.11.0.

Let's accept anything below 3.12.

Note: It may be a good idea to remove entirely the upper bound, see this discussion https://discuss.python.org/t/requires-python-upper-limits/12663/5