### PR TITLE
feat: Store setup result on Provider object

### DIFF
--- a/cloudbees/provider.py
+++ b/cloudbees/provider.py
@@ -15,7 +15,8 @@ class CloudbeesProvider(AbstractProvider):
         
         if rox_options is None:
             rox_options = RoxOptions()
-        Rox.setup(api_key, rox_options).result(timeout)
+        
+        self.setup_result = Rox.setup(api_key, rox_options).result(timeout)
 
     def get_metadata(self) -> Metadata:
         return Metadata("Cloudbees")


### PR DESCRIPTION
This PR stores the result of `Rox.setup()` as an instance variable on the `CloudbeesProvider` object upon initialization.

This is done in order to have access to the result object from outside of the provider. 
More specifically, I found this to be required in order to implement the CloudBees recommended resolution of the following issue: 
https://docs.cloudbees.com/docs/cloudbees-feature-flags-kb/latest/cloudbees-feature-flags-kb/python-software-hangs-after-the-rollout-python-sdk-is-instantiated

With this change in place, this issue can now be solved when using OpenFeature by calling: 
```python
cloudbees_provider = CloudbeesProvider(...)
cloudbees_provider.setup_result.set()
```